### PR TITLE
fix: prototype-key handling, cyclic-parent guard, and stale JSDoc

### DIFF
--- a/src/raFile.ts
+++ b/src/raFile.ts
@@ -1,4 +1,5 @@
 import RaStanza from './raStanza.ts'
+import { nullProtoRecord } from './util.ts'
 
 /**
  * Class representing an ra file. Each file is composed of multiple stanzas,
@@ -20,7 +21,7 @@ import RaStanza from './raStanza.ts'
  * validation step
  */
 export default class RaFile {
-  data: Record<string, RaStanza> = {}
+  data: Record<string, RaStanza> = nullProtoRecord()
 
   nameKey?: string
 

--- a/src/raFile.ts
+++ b/src/raFile.ts
@@ -1,24 +1,23 @@
 import RaStanza from './raStanza.ts'
 
 /**
- * Class representing an ra file. Each file is composed of multiple stanzas, and
- * each stanza is separated by one or more blank lines. Each stanza is stored in
- * a Map with the key being the value of the first key-value pair in the stanza.
- * The usual Map methods can be used on the file. An additional method `add()`
- * is available to take a raw line of text and break it up into a key and value
- * and add them to the class. This should be favored over `set()` when possible,
- * as it performs more validity checks than using `set()`.
+ * Class representing an ra file. Each file is composed of multiple stanzas,
+ * separated by one or more blank lines. Each stanza is stored in the `data`
+ * record, keyed by the value of the first key-value pair in the stanza. Lines
+ * that are entirely comments (`#`) and `include` directives are skipped.
  * @property {undefined|string} nameKey - The key of the first line of all the
- * stanzas (`undefined` if the stanza has no lines yet).
+ * stanzas (`undefined` if the file has no stanzas yet).
  * @throws {Error} Throws if an empty stanza is added, if the key in the first
  * key-value pair of each stanza isn't the same, or if two stanzas have the same
  * value for the key-value pair in their first lines.
  * @param {(string|string[])} [raFile=[]] - An ra file, either as a single
  * string or an array of strings with one stanza per entry. Supports both LF
  * and CRLF line terminators.
- * @param {object} options
- * @param {boolean} options.checkIndent [true] - Check if a the stanzas within
+ * @param {object} [options]
+ * @param {boolean} [options.checkIndent=true] - Check that the stanzas within
  * the file are indented consistently and keep track of the indentation
+ * @param {boolean} [options.skipValidation=false] - Skip the subclass
+ * validation step
  */
 export default class RaFile {
   data: Record<string, RaStanza> = {}
@@ -62,7 +61,7 @@ export default class RaFile {
       if (!raStanza.name) {
         throw new Error(`No stanza name: ${raStanza.name}`)
       }
-      if (this.data[raStanza.name]) {
+      if (Object.hasOwn(this.data, raStanza.name)) {
         throw new Error(`Got duplicate stanza name: ${raStanza.name}`)
       }
 

--- a/src/raStanza.ts
+++ b/src/raStanza.ts
@@ -1,10 +1,12 @@
+import { nullProtoRecord } from './util.ts'
+
 /**
  * Class representing an ra file stanza. Each line is split into its key and
  * value and stored in the `data` record. The key and value of the first line
  * are also exposed as `nameKey` and `name`.
  */
 export default class RaStanza {
-  data: Record<string, string> = {}
+  data: Record<string, string> = nullProtoRecord()
 
   name?: string
 

--- a/src/raStanza.ts
+++ b/src/raStanza.ts
@@ -1,7 +1,7 @@
 /**
- * Class representing an ra file stanza. Each stanza line is split into its key
- * and value and stored as a Map, so the usual Map methods can be used on the
- * stanza.
+ * Class representing an ra file stanza. Each line is split into its key and
+ * value and stored in the `data` record. The key and value of the first line
+ * are also exposed as `nameKey` and `name`.
  */
 export default class RaStanza {
   data: Record<string, string> = {}
@@ -59,7 +59,7 @@ export default class RaStanza {
           )
         }
         // Adding a key that already exists and has no value is a no-op
-        if (this.data[trimmedLine]) {
+        if (Object.hasOwn(this.data, trimmedLine)) {
           continue
         }
         this.data[trimmedLine] = ''
@@ -67,7 +67,7 @@ export default class RaStanza {
       }
       const key = trimmedLine.slice(0, sep)
       const value = trimmedLine.slice(sep + 1)
-      if (key in this.data && this.data[key] !== value) {
+      if (Object.hasOwn(this.data, key) && this.data[key] !== value) {
         throw new Error(
           'Got duplicate key with a different value in stanza: ' +
             `"${key}" key has both ${this.data[key]} and ${value}`,

--- a/src/trackDbFile.ts
+++ b/src/trackDbFile.ts
@@ -62,14 +62,19 @@ export default class TrackDbFile extends RaFile {
    * @throws {Error} Throws if track name does not exist in the trackDb
    */
   settings(trackName: string) {
-    if (!this.data[trackName]) {
+    if (!Object.hasOwn(this.data, trackName)) {
       throw new Error(`Track ${trackName} does not exist`)
     }
     const parentTracks = [trackName]
-    let currentTrackName: string = trackName
+    const seen = new Set([trackName])
+    let currentTrackName = trackName
     let parent = this.data[currentTrackName]?.data.parent
     while (parent) {
       currentTrackName = parent.split(' ')[0] ?? currentTrackName
+      if (seen.has(currentTrackName)) {
+        break
+      }
+      seen.add(currentTrackName)
       parentTracks.push(currentTrackName)
       parent = this.data[currentTrackName]?.data.parent
     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,12 @@
 import type RaStanza from './raStanza.ts'
 
+// A prototype-free record, so keys that collide with Object.prototype members
+// ("__proto__", "constructor", "toString", ...) are stored as plain data
+// instead of being silently dropped or reparenting the object.
+export function nullProtoRecord<V>(): Record<string, V> {
+  return Object.create(null)
+}
+
 // validate that all required fields are present in the map
 export function validateRequiredFieldsArePresent(
   map: RaStanza,

--- a/test/raFile.test.ts
+++ b/test/raFile.test.ts
@@ -54,6 +54,14 @@ test('handles indented stanzas', () => {
   expect(raFile.nameKey).toEqual('key1')
 })
 
+test('stores a stanza whose name collides with Object.prototype', () => {
+  const raFile = new RaFile(
+    'key1 __proto__\nkey2 b\n\nkey1 constructor\nkey2 c\n',
+  )
+  expect(Object.keys(raFile.data)).toEqual(['__proto__', 'constructor'])
+  expect(raFile.data.__proto__?.data.key2).toEqual('b')
+})
+
 test('throws on an empty stanza', () => {
   expect(() => new RaFile('')).toThrow(/Invalid stanza, was empty/)
 })

--- a/test/raStanza.test.ts
+++ b/test/raStanza.test.ts
@@ -111,6 +111,11 @@ test('treats a repeated bare key as a no-op rather than overwriting', () => {
   expect(stanza.data.key2).toEqual('value2')
 })
 
+test('handles keys that collide with Object.prototype members', () => {
+  const stanza = new RaStanza('key1 value1\ntoString custom\nconstructor ctor\n')
+  expect(stanza.data).toMatchObject({ toString: 'custom', constructor: 'ctor' })
+})
+
 test('throws on encountering blank lines', () => {
   expect(() => new RaStanza('key1 value1\n\nkey2 value2')).toThrow(
     /contained blank lines/,

--- a/test/raStanza.test.ts
+++ b/test/raStanza.test.ts
@@ -112,8 +112,17 @@ test('treats a repeated bare key as a no-op rather than overwriting', () => {
 })
 
 test('handles keys that collide with Object.prototype members', () => {
-  const stanza = new RaStanza('key1 value1\ntoString custom\nconstructor ctor\n')
-  expect(stanza.data).toMatchObject({ toString: 'custom', constructor: 'ctor' })
+  const stanza = new RaStanza(
+    'key1 value1\ntoString custom\nconstructor ctor\n__proto__ p\n',
+  )
+  expect(Object.hasOwn(stanza.data, 'toString')).toBe(true)
+  expect(Object.hasOwn(stanza.data, 'constructor')).toBe(true)
+  expect(Object.hasOwn(stanza.data, '__proto__')).toBe(true)
+  expect(stanza.data).toMatchObject({
+    toString: 'custom',
+    constructor: 'ctor',
+    ['__proto__']: 'p',
+  })
 })
 
 test('throws on encountering blank lines', () => {

--- a/test/trackDbFile.test.ts
+++ b/test/trackDbFile.test.ts
@@ -84,6 +84,14 @@ test('settings() merges parent entries with child overriding', () => {
   })
 })
 
+test('settings() terminates on a cyclic parent chain', () => {
+  const input =
+    'track a\nsuperTrack on\nshortLabel a\ntype bigBed\nparent b\n\n' +
+    'track b\nsuperTrack on\nshortLabel b\ntype bigBed\nparent a\n'
+  const trackDb = new TrackDbFile(input)
+  expect(trackDb.settings('a')).toMatchObject({ track: 'a' })
+})
+
 test("throws if trying to get settings for a track that doesn't exist", () => {
   expect(() =>
     new TrackDbFile(fs.readFileSync('test/basic.trackDb.txt', 'utf8')).settings(


### PR DESCRIPTION
## Summary

Small correctness pass on the ra/trackDb parsers.

- **`settings()` infinite loop** — the parent-chain walk had no cycle protection, so a self-referential or mutually-cyclic `parent` chain (A→B→A) would hang. Added a `seen` set that breaks the walk on revisit.
- **Prototype-free key storage** — `RaStanza.data` and `RaFile.data` now use `Object.create(null)` (via a typed `nullProtoRecord()` helper). Keys/stanza-names that collide with `Object.prototype` members are now stored as plain data instead of being silently dropped:
  - a `__proto__ x` line was a no-op write (the inherited setter ignores string values), so the entry was lost
  - a stanza *named* `__proto__` in an `RaFile` reparented the data object (values there are `RaStanza` objects) instead of being stored
  - `Object.hasOwn` now used for membership checks so `toString`/`constructor`-named keys don't trigger spurious duplicate-key/duplicate-name errors
- **Stale JSDoc** — `RaFile`/`RaStanza` docstrings described a removed `Map`-based `add()`/`set()` API; rewritten to match the current `Record`-based API, and the `skipValidation` option is now documented.

### Not a security vuln

This is **not** global prototype pollution: there's no recursive deep-merge and no nested `obj[a][b]=c` assignment — the only write sinks are flat `data[key]=value` on per-instance objects, so `Object.prototype` is never mutated. The dropped/mis-stored entries were a plain correctness bug, fixed here for robustness since hub files are fetched from arbitrary URLs.

## Test plan

- Added regression tests: prototype-colliding keys in `RaStanza`, prototype-colliding stanza names in `RaFile`, and cyclic-parent termination in `TrackDbFile` (the cycle test would have hung before the fix).
- `pnpm test` — 46 passing, no snapshot churn
- `pnpm lint`, `tsc --noEmit`, `pnpm build` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)